### PR TITLE
PM restrict more: into main

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,0 +1,17 @@
+2023-03-27  Klaus Weide  <kweide@uchicago.edu>
+
+	* source/mpi_amr_1blk_restrict.F90: request data for restriction
+	also into ANCESTOR blocks, if the ancestor data could potentially
+	be needed for purposes of (de)refinement criteria. Such a
+	potential need is assumed if the ANCESTOR has at least one
+	same-level neighbor of type 2 (PARENT) and the ANCESTOR's
+	refinement level is not below lrefine_min.
+
+2023-03-26  Klaus Weide  <kweide@uchicago.edu>
+
+	* source/mpi_morton_bnd_restrict.F90: request data for restriction
+	also into ANCESTOR blocks, if the ancestor data could potentially
+	be needed for purposes of (de)refinement criteria. Such a
+	potential need is assumed if the ANCESTOR has at least one
+	same-level neighbor of type 2 (PARENT) and the ANCESTOR's
+	refinement level is not below lrefine_min.

--- a/source/mpi_amr_1blk_restrict.F90
+++ b/source/mpi_amr_1blk_restrict.F90
@@ -106,6 +106,9 @@
 !!
 !!   Peter MacNeice (February 1999).
 !!
+!! MODIFICATIONS
+!!
+!!  2023-03-27 K. Weide  Also restrict into ANCESTOR blocks "where needed"
 !!***
 
 !!REORDER(5): unk, facevar[xyz], tfacevar[xyz]
@@ -270,7 +273,7 @@ Subroutine mpi_amr_1blk_restrict(mype,iopt,lcc,lfc,lec,lnc,      &
 
 !-----Is this a parent block of at least one leaf node?
               If ((nodetype(lb) == 2 .and. lrefine(lb) == level) .or. &
-                  (nodetype(lb) == 3 .and. &
+                  (nodetype(lb) == 3 .and. lrefine(lb) == level .AND. &
                      (lrefine(lb) .GE. lrefine_min) .AND. &
                      ANY(surr_blks(3,:,1:1+2*k2d,1:1+2*k3d,lb)==2)) .OR. &
                   (nodetype(lb) == 2 .and. filling_guardcells)) Then

--- a/source/mpi_amr_1blk_restrict.F90
+++ b/source/mpi_amr_1blk_restrict.F90
@@ -109,6 +109,7 @@
 !! MODIFICATIONS
 !!
 !!  2023-03-27 K. Weide  Also restrict into ANCESTOR blocks "where needed"
+!!  2023-03-27 K. Weide  Ancestors accept data from children who are ancestors
 !!***
 
 !!REORDER(5): unk, facevar[xyz], tfacevar[xyz]
@@ -309,7 +310,7 @@ Subroutine mpi_amr_1blk_restrict(mype,iopt,lcc,lfc,lec,lnc,      &
                     cnodetype = nodetype(remote_block)
                     cempty = empty(remote_block)
 
-                    If (cnodetype <= 2 .and. cempty == 0 ) Then
+                    If ( cempty == 0 ) Then
 
 !--------compute the offset in the parent block appropriate for this child
                        ioff = mod(jchild-1,2)*nxb/2

--- a/source/mpi_amr_1blk_restrict.F90
+++ b/source/mpi_amr_1blk_restrict.F90
@@ -270,6 +270,9 @@ Subroutine mpi_amr_1blk_restrict(mype,iopt,lcc,lfc,lec,lnc,      &
 
 !-----Is this a parent block of at least one leaf node?
               If ((nodetype(lb) == 2 .and. lrefine(lb) == level) .or. &
+                  (nodetype(lb) == 3 .and. &
+                     (lrefine(lb) .GE. lrefine_min) .AND. &
+                     ANY(surr_blks(3,:,1:1+2*k2d,1:1+2*k3d,lb)==2)) .OR. &
                   (nodetype(lb) == 2 .and. filling_guardcells)) Then
 
 

--- a/source/mpi_amr_1blk_restrict.F90
+++ b/source/mpi_amr_1blk_restrict.F90
@@ -184,6 +184,7 @@ Subroutine mpi_amr_1blk_restrict(mype,iopt,lcc,lfc,lec,lnc,      &
   Integer,Save :: llrefine_min,llrefine_max
   Integer,Save :: llrefine_mint,llrefine_maxt
 
+
   Logical :: l_srl_only,ldiag
   Logical :: lguard,lprolong,lflux,ledge,lrestrict
   Logical :: lfound
@@ -192,6 +193,7 @@ Subroutine mpi_amr_1blk_restrict(mype,iopt,lcc,lfc,lec,lnc,      &
   include 'mpif.h'
 
 !-----Begin Executable Code
+
   nguard0 = nguard*npgs
   nguard1 = nguard - nguard0
   nguard_work0 = nguard_work*npgs

--- a/source/mpi_amr_restrict_fulltree.F90
+++ b/source/mpi_amr_restrict_fulltree.F90
@@ -63,36 +63,33 @@
       integer, intent(in)  :: mype,iopt
       logical, intent(in)  :: lcc,lfc,lec,lnc
 
-      integer nguard0,nguard_work0
-
 #ifdef REAL8
       real,parameter :: tiny = 1.d-40
 #else
       real,parameter :: tiny = 1.e-25
 #endif
 
+!-----Local Variables and Arrays
+      integer nguard0,nguard_work0
+
 !------------------------------------
 ! local arrays
-
 
       real temp(nvar,il_bnd1:iu_bnd1,jl_bnd1:ju_bnd1,kl_bnd1:ku_bnd1)
       real send(nvar,il_bnd1:iu_bnd1,jl_bnd1:ju_bnd1,kl_bnd1:ku_bnd1)
 
       real recvn0(nbndvarc,il_bnd:iu_bnd+1,jl_bnd:ju_bnd+k2d, & 
      &                                      kl_bnd:ku_bnd+k3d)
-      real tempn(nbndvarc,il_bnd1:iu_bnd1+1,jl_bnd1:ju_bnd1+k2d, & 
-     &                                      kl_bnd1:ku_bnd1+k3d)
-      real sendn(nbndvarc,il_bnd1:iu_bnd1+1,jl_bnd1:ju_bnd1+k2d, & 
-     &                                      kl_bnd1:ku_bnd1+k3d)
+    Real tempn(nbndvarc,il_bnd1:iu_bnd1+1,jl_bnd1:ju_bnd1+k2d,       &
+                                          kl_bnd1:ku_bnd1+k3d)
+    Real sendn(nbndvarc,il_bnd1:iu_bnd1+1,jl_bnd1:ju_bnd1+k2d,       &
+                                          kl_bnd1:ku_bnd1+k3d)
 
       integer ::  maxbnd
-      real,allocatable :: tempf(:,:,:,:)
-      real,allocatable :: sendf(:,:,:,:)
-
+  Real,Allocatable :: tempf(:,:,:,:)
+  Real,Allocatable :: sendf(:,:,:,:)
 
       logical l_srl_only,ldiag
-
-
       logical :: lguard,lprolong,lflux,ledge,lrestrict,lfulltree
       logical :: lfound
 
@@ -114,14 +111,16 @@
       integer :: i1,i2,j1,j2,k1,k2
 
 !------------------------------------
+
+!-----Begin Executable Code
 #ifdef DEBUG_FLOW_TRACE
       write(*,*) 'entered mpi_amr_restrict_fulltree: pe ',mype, & 
      &           ' iopt ',iopt
 #endif /* DEBUG_FLOW_TRACE */
 
 
-      nguard0 = nguard*npgs
-      nguard_work0 = nguard_work*npgs
+  nguard0 = nguard*npgs
+  nguard_work0 = nguard_work*npgs
 
       maxbnd = max(nbndvare,nbndvarc,nbndvar)
       allocate(  & 
@@ -169,8 +168,7 @@
 
 
       if(llrefine_max.gt.llrefine_min) then
-      do level = llrefine_max-1,llrefine_min,-1
-
+     Do level = llrefine_max-1,llrefine_min,-1
 
 
 ! Now parents of leaf nodes get data
@@ -198,8 +196,8 @@
      &                        lflux,ledge,lrestrict,lfulltree, & 
      &                        iopt,lcc,lfc,lec,lnc,tag_offset)
 
-      if(lnblocks.gt.0) then
-      do lb = 1,lnblocks
+        If (lnblocks > 0) Then
+           Do lb = 1,lnblocks
 
 
 
@@ -207,15 +205,15 @@
       if(nodetype(lb).ge.2.and.lrefine(lb).eq.level) then
 
 
-! If yes then cycle through its children.
-      do ich=1,nchild
+!-----If yes then cycle through its children.
+                 Do ich=1,nchild
 
         jchild = ich
 
 
-! Is this child a leaf block? If it is then fetch its data.
-        remote_pe     = child(2,ich,lb)
-        remote_block  = child(1,ich,lb)
+!-------Is this child a leaf block? If it is then fetch its data.
+                    remote_pe     = child(2,ich,lb)
+                    remote_block  = child(1,ich,lb)
 
 #ifdef DEBUG
          write(*,*) 'pe ',mype,' blk ',lb,' searching for child ', & 

--- a/source/mpi_morton_bnd_restrict.F90
+++ b/source/mpi_morton_bnd_restrict.F90
@@ -58,6 +58,8 @@
 !!    Written by Peter MacNeice  and Michael Gehmeyr, February 2000.
 !!    Major simplification and rewrite by Kevin Olson, August 2007.
 !!
+!! MODIFICATIONS
+!!  2023-03-26 K. Weide  Request data for restriction into ANCESTORs as needed
 !!***
 
 !!REORDER(5): unk, facevar[xyz], tfacevar[xyz]

--- a/source/mpi_morton_bnd_restrict.F90
+++ b/source/mpi_morton_bnd_restrict.F90
@@ -136,6 +136,9 @@
       Do lb = 1, lnblocks
 
       If (nodetype(lb) == 2 .or.                                       &
+          (nodetype(lb) == 3 .AND. &
+             (lrefine(lb) .GE. lrefine_min) .AND. &
+             ANY(surr_blks(3,:,1:1+2*k2d,1:1+2*k3d,lb)==2))       .OR. &
           (advance_all_levels .and. nodetype(lb) == 3)) Then
 
 !------ADD OFF PROCESSOR CHILDREN OF BLOCK 'lb' TO FETCH LIST


### PR DESCRIPTION
A separate PM_restrictMore branch should not be needed any more.
Branches `main` and friends of the `Flash-X` repo should now again just refer to the `main` branch, rather than the `PM_restrictMore` branch, of the `PARAMESH-for-Flash-X` repo loaded as the `PM4_package` submodule.